### PR TITLE
fix assignment of host address

### DIFF
--- a/baremetal_support.py
+++ b/baremetal_support.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
         port = args.port
 
     if args.listen:
-        host - args.listen
+        host = args.listen
 
     server = Baremetal_Support(host=host, port=port)
     server.start()


### PR DESCRIPTION
Due to a typo, the 'host' value got subtracted by the command line argument
'args.listen' instead of assigned to 'args.listen'.

Fix this up by assigning 'args.listen'

Signed-off-by: Johannes Thumshirn <jthumshirn@suse.de>