### PR TITLE
Add tokens to identify legit lock owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ All parameters in this documentation are surrounded by <>.
 ### Lock related API
 #### /v1/host_lock/lock/<addr>
 - GET
-  take the lock if possible. If the host is already locked, HTTP status 412 is
-  returned
+  take the lock if possible and return a token in the response body.
+  If the host is already locked, HTTP status 412 is returned. 
+#### /v1/host_lock/lock/<addr>/<token>
 - PUT
+  token is retrieved when locking, this needs to be passed to the unlock.
   free the lock. If it is not locked, HTTP status 412 signals the error.
 #### /v1/host_lock/lock_state/<addr>
 - GET

--- a/tests/test_baremetal_Support.py
+++ b/tests/test_baremetal_Support.py
@@ -89,13 +89,14 @@ def test_baremetal_support():
 
     r10 = requests.get(url_lock)
     assert r10.status_code == 200
-    assert r10.text == 'ok'
+    token = r10.text
 
     r11 = requests.get(url_status)
     assert r11.status_code == 200
     assert r11.text == 'locked'
 
-    r12 = requests.put(url_unlock)
+    url_unlock2 = url_unlock + '/' + token
+    r12 = requests.put(url_unlock2)
     assert r12.status_code == 200
     assert r12.text == 'ok'
 
@@ -106,7 +107,7 @@ def test_baremetal_support():
     print(url_lock_timeout)
     r14 = requests.get(url_lock_timeout)
     assert r14.status_code == 200
-    assert r14.text == 'ok'
+    assert r14.text != ''
 
     r15 = requests.get(url_status)
     assert r15.status_code == 200
@@ -120,21 +121,25 @@ def test_baremetal_support():
 
     r17 = requests.get(url_lock)
     assert r17.status_code == 200
-    assert r17.text == 'ok'
+    token = r17.text
 
     r18 = requests.get(url_lock)
     assert r18.status_code == 412
 
-    r19 = requests.put(url_unlock)
-    assert r19.status_code == 200
-    assert r19.text == 'ok'
+    r19 = requests.put(url_unlock + '/0xdeadbeefcafebabe')
+    assert r19.status_code == 403
 
-    r20 = requests.get(url_status)
+    url_unlock3 = url_unlock + '/' + token
+    r20 = requests.put(url_unlock3)
     assert r20.status_code == 200
-    assert r20.text == 'unlocked'
+    assert r20.text == 'ok'
 
-    r21 = requests.put(url_unlock)
-    assert r21.status_code == 412
+    r21 = requests.get(url_status)
+    assert r21.status_code == 200
+    assert r21.text == 'unlocked'
+
+    r22 = requests.put(url_unlock3)
+    assert r22.status_code == 412
 
     p.terminate()
     p.join()

--- a/tests/test_host_lock.py
+++ b/tests/test_host_lock.py
@@ -16,8 +16,9 @@ def test_my_timer():
     locks = Host_Lock(app)
 
     assert not locks.is_locked(host0)
-    locks.lock_host(host0, 6)
+    token = locks.lock_host(host0, 6)
     assert locks.is_locked(host0)
+    assert token != ''
     time.sleep(2)
     assert locks.is_locked(host0)
     time.sleep(9)
@@ -32,21 +33,21 @@ def test_is_locked():
     assert not locks.is_locked(host0)
     assert not locks.is_locked(host1)
 
-    locks.lock_host(host0)
+    token = locks.lock_host(host0)
     assert locks.is_locked(host0)
     assert locks.locks[host0]
     print(locks.locks[host0])
     assert not locks.is_locked(host1)
 
-    locks.lock_host(host1)
+    token2 = locks.lock_host(host1)
     assert locks.is_locked(host0)
     assert locks.is_locked(host1)
 
-    locks.unlock_host(host0)
+    locks.unlock_host(host0, token)
     assert not locks.is_locked(host0)
     assert locks.is_locked(host1)
 
-    locks.unlock_host(host1)
+    locks.unlock_host(host1, token2)
     assert not locks.is_locked(host0)
     assert not locks.is_locked(host1)
 
@@ -61,9 +62,9 @@ def test_lock_host():
 def test_unlock_host():
     app = Bottle()
     locks = Host_Lock(app)
-    locks.lock_host(host1)
+    token = locks.lock_host(host1)
     assert locks.locks[host1]
-    locks.unlock_host(host1)
+    locks.unlock_host(host1, token)
     assert not locks.locks[host1]
 
 
@@ -72,13 +73,13 @@ def test_lock_already_locked():
     locks = Host_Lock(app)
 
     assert not locks.is_locked(host0)
-    locks.lock_host(host0)
+    token = locks.lock_host(host0)
     assert locks.is_locked(host0)
 
     with raises(HostAlreadyLocked):
         locks.lock_host(host0)
 
-    locks.unlock_host(host0)
+    locks.unlock_host(host0, token)
     locks.lock_host(host0)
 
     with raises(HostAlreadyLocked):
@@ -91,4 +92,4 @@ def test_unlock_unlocked():
 
     assert not locks.is_locked(host0)
     with raises(HostNotLocked):
-        locks.unlock_host(host0)
+        locks.unlock_host(host0, '')


### PR DESCRIPTION
Previously, everyone could unlock a machine locked by someone else.
Unfortunately, when we unlock the machine in a post-fail-hook in openQA,
we will unlock any machine, even if it is locked, and even if we just
failed to lock it.
This commit introduces randomly generated tokens, which need to be
passed when unlocking a host, otherwise the unlock will fail.

Signed-off-by: Michael Moese <mmoese@suse.de>