### PR TITLE
Allow test execution in offline environments

### DIFF
--- a/tests/test_baremetal_Support.py
+++ b/tests/test_baremetal_Support.py
@@ -146,12 +146,16 @@ def test_baremetal_support():
     assert r22.status_code == 412
 
     # tests for jobid.py
-    r23 = requests.get(url_jobid_good)
-    assert r23.status_code == 200
-    assert r23.text != ""
+    try:
+        reachable = requests.get(instance)
+        r23 = requests.get(url_jobid_good)
+        assert r23.status_code == 200
+        assert r23.text != ""
 
-    r24 = requests.get(url_jobid_bad)
-    assert r24.status_code != 200
+        r24 = requests.get(url_jobid_bad)
+        assert r24.status_code != 200
+    except Exception:
+        pytest.skip("instance unreachable")
 
     p.terminate()
     p.join()

--- a/tests/test_jobid.py
+++ b/tests/test_jobid.py
@@ -2,15 +2,21 @@
 # SPDX-License-Identifier: GPL-3.0
 
 from bottle import Bottle
-from pytest import raises
+from pytest import raises, skip
+import requests
 
 from baremetal_support.jobid import LatestJob, LatestJobNotFound
 
 
 def test_exception():
+    instance = 'http://openqa.opensuse.org'
+    try:
+        reachable = requests.get(instance)
+    except Exception:
+        pytest.skip("instance unreachable")
+        
     app = Bottle()
-    # retrieve value after setting it
-    lj = LatestJob(app)
+    lj = LatestJob(app, instance)
 
     filter = {}
     filter['arch'] = 'MIPS'
@@ -22,8 +28,14 @@ def test_exception():
         res = lj.get_latest_job(filter)
 
 def test_get():
+    instance = 'http://openqa.opensuse.org'
+    try:
+        reachable = requests.get(instance)
+    except Exception:
+        pytest.skip("instance unreachable")
+
     app = Bottle()
-    lj = LatestJob(app, 'http://openqa.opensuse.org')
+    lj = LatestJob(app, instance)
     filter = {}
     filter['arch'] = 'x86_64'
     filter['distri'] = 'opensuse'


### PR DESCRIPTION
When running the tests in Open Build Service, the connection to
openqa.opensuse.org is not possible. In this case, the tests should not
fail, but those should be skipped. For package generation, we don't need
to have full coverage.