### PR TITLE
style(*): improve python style checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+uv.lock
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,24 @@
+.PHONY: help
+help:
+	@echo "Call one of the available targets:"
+	@sed -n 's/\(^[^.#[:space:]A-Z]*\):.*$$/\1/p' Makefile | uniq
 
+.PHONY: init
 init:
-	pip install -r requirements.txt
+	uv sync
 
+# Override to use uv, e.g. PYTHON_RUN="uv run"
+PYTHON_RUN ?=
+
+.PHONY: test
 test:
-	pycodestyle baremetal_support/baremetal_support.py
-	pycodestyle baremetal_support/bootscript.py
-	pycodestyle baremetal_support/lock.py
-	pycodestyle baremetal_support/jobid.py
-	pycodestyle tests/test_bootscript.py
-	pycodestyle tests/test_host_lock.py
-	pycodestyle tests/test_bootscript.py
-	pycodestyle tests/test_jobid.py
-	py.test -s --cov-report=term --cov=baremetal_support tests/ 
+	$(PYTHON_RUN) py.test -s --cov-report=term --cov=baremetal_support tests/
 
-.PHONY: init test
+.PHONY: tidy
+tidy: ## Format code and fix linting issues
+	ruff format
+	ruff check --fix
+
+.PHONY: check-types-ty
+check-types-ty: ## Run ty type checker
+	ty check

--- a/baremetal_support.py
+++ b/baremetal_support.py
@@ -7,27 +7,35 @@ from baremetal_support.logging import Logging
 import yaml
 
 
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("-l", "--listen",
-                        help="hostname to listen on - defaults to all")
-    parser.add_argument("-p", "--port",
-                        type=int,
-                        help="specify listening port - defaults to 8080")
-    parser.add_argument("-i", "--instance",
-                        help="specify openQA instance - defaults to http://openqa.suse.de")
-    parser.add_argument("-m", "--loglevel",
-                        help="Loglevel to use, one of DEBUG, INFO, WARNING, ERROR, CRITICAL, default is INFO")
-    parser.add_argument("-c", "--config",
-                        help="Specify configuration file to use. Will not use a default. "
-                        "command line settings override settings in the config file")
+    parser.add_argument("-l", "--listen", help="hostname to listen on - defaults to all")
+    parser.add_argument("-p", "--port", type=int, help="specify listening port - defaults to 8080")
+    parser.add_argument(
+        "-i",
+        "--instance",
+        help="specify openQA instance - defaults to http://openqa.suse.de",
+    )
+    parser.add_argument(
+        "-m",
+        "--loglevel",
+        help="Loglevel to use, one of DEBUG, INFO, WARNING, ERROR, CRITICAL, default is INFO",
+    )
+    parser.add_argument(
+        "-c",
+        "--config",
+        help="Specify configuration file to use. Will not use a default. "
+        "command line settings override settings in the config file",
+    )
 
     args = parser.parse_args()
 
     if args.config:
-        with open(args.config, "r",) as ymlfile:
+        with open(
+            args.config,
+            "r",
+        ) as ymlfile:
             conf = yaml.safe_load(ymlfile)
             cfg = conf["baremetal_support"]
     if args.port:

--- a/baremetal_support/baremetal_support.py
+++ b/baremetal_support/baremetal_support.py
@@ -4,12 +4,11 @@ from bottle import Bottle
 
 from .bootscript import Bootscript
 from .lock import Host_Lock
-from . jobid import LatestJob
-from .logging import Logging
+from .jobid import LatestJob
 
 
 if __name__ == "__main__":
-    import argparse
+    pass
 
 
 class Baremetal_Support:
@@ -32,18 +31,25 @@ class Baremetal_Support:
         # unversioned API is deprecated!
         self.log.debug("routing legacy API endpoints")
         self.log.debug("/script.ipxe [GET]")
-        self._app.route('/script.ipxe',
-                        method="GET",
-                        callback=self._bootscript.http_get_bootscript_for_peer)
+        self._app.route(
+            "/script.ipxe",
+            method="GET",
+            callback=self._bootscript.http_get_bootscript_for_peer,
+        )
         self.log.debug("/<addr>/script.ipxe [POST][GET]")
-        self._app.route('/<addr>/script.ipxe',
-                        method="POST",
-                        callback=self._bootscript.http_set_bootscript)
-        self._app.route('/<addr>/script.ipxe',
-                        method="GET",
-                        callback=self._bootscript.http_get_bootscript)
+        self._app.route(
+            "/<addr>/script.ipxe",
+            method="POST",
+            callback=self._bootscript.http_set_bootscript,
+        )
+        self._app.route(
+            "/<addr>/script.ipxe",
+            method="GET",
+            callback=self._bootscript.http_get_bootscript,
+        )
 
         # bootscript API
+
     def start(self):
         self.log.info("Starting baremetal support service")
         self._app.run(host=self._host, port=self._port, debug=True)

--- a/baremetal_support/bootscript.py
+++ b/baremetal_support/bootscript.py
@@ -7,6 +7,7 @@ import socket
 
 class BootscriptNotFound(Exception):
     """Raised when the address is invalid"""
+
     pass
 
 
@@ -15,24 +16,30 @@ class Bootscript:
         self.bootscript = {}
         self._app = app
         self.log = logger
-        self._app.route('/v1/bootscript/script.ipxe',
-                        method="GET",
-                        callback=self.http_get_bootscript_for_peer)
-        self._app.route('/v1/bootscript/script.ipxe/<addr>',
-                        method="POST",
-                        callback=self.http_set_bootscript)
-        self._app.route('/v1/bootscript/script.ipxe/<addr>',
-                        method="GET",
-                        callback=self.http_get_bootscript)
+        self._app.route(
+            "/v1/bootscript/script.ipxe",
+            method="GET",
+            callback=self.http_get_bootscript_for_peer,
+        )
+        self._app.route(
+            "/v1/bootscript/script.ipxe/<addr>",
+            method="POST",
+            callback=self.http_set_bootscript,
+        )
+        self._app.route(
+            "/v1/bootscript/script.ipxe/<addr>",
+            method="GET",
+            callback=self.http_get_bootscript,
+        )
 
     def set(self, ip, script):
-        """ set the bootscript in the dict """
+        """set the bootscript in the dict"""
         self.log.info("setting bootscript for " + ip)
         self.log.debug(script)
         self.bootscript[ip] = script
 
     def get(self, ip):
-        """ return specific bootscript """
+        """return specific bootscript"""
         try:
             self.log.info("retrieving bootscript for " + ip)
             return self.bootscript[ip]
@@ -48,14 +55,14 @@ class Bootscript:
             return False
 
     def http_get_bootscript_for_peer(self):
-        addr = bottle.request.environ.get('REMOTE_ADDR')
+        addr = bottle.request.environ.get("REMOTE_ADDR")
         self.log.debug("http request: get bootscript for peer (" + addr + ")")
         return self.http_get_bootscript(addr)
 
     def http_get_bootscript(self, addr):
         try:
             if self._is_ip(addr):
-                bottle.response.content_type = 'text/text; charset=utf-8'
+                bottle.response.content_type = "text/text; charset=utf-8"
                 self.log.debug("http request: get bootscript for " + addr)
                 return self.get(addr)
             else:
@@ -64,20 +71,18 @@ class Bootscript:
         except BootscriptNotFound:
             # no script found for this IP
             self.log.debug("http request: no bootscript found for " + addr)
-            bottle.response.body = 'not found'
-            bottle.response.status = '404 Not Found'
+            bottle.response.body = "not found"
+            bottle.response.status = "404 Not Found"
             return bottle.response
 
     def http_set_bootscript(self, addr):
         if self._is_ip(addr):
             postdata = bottle.request.body.read()
-            script = postdata.decode('utf-8')
+            script = postdata.decode("utf-8")
             self.log.info("http request: set bootscript for " + addr)
             self.log.debug(script)
             self.set(addr, script)
             bottle.response.status = 200
         else:
-            self.log.debug("http request: not setting bootscript,"
-                           " invalid address given: "
-                           + addr)
+            self.log.debug("http request: not setting bootscript, invalid address given: " + addr)
             bottle.response.status = 400

--- a/baremetal_support/jobid.py
+++ b/baremetal_support/jobid.py
@@ -1,36 +1,32 @@
 # Copyright (C) 2020-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-3.0
 
-import os
 import bottle
-import socket
 from openqa_client.client import OpenQA_Client
 
 
 class LatestJobNotFound(Exception):
     """Raised when no job is found"""
+
     pass
 
 
 class LatestJob:
-    def __init__(self, app, logger, instance='http://openqa.suse.de'):
-        route = '/v1/latest_job/<arch>/<distri>/<flavor>/<version>/<test>'
+    def __init__(self, app, logger, instance="http://openqa.suse.de"):
+        route = "/v1/latest_job/<arch>/<distri>/<flavor>/<version>/<test>"
         self.bootscript = {}
         self._instance = instance
         self._app = app
         self.log = logger
-        self._app.route(route,
-                        method="GET",
-                        callback=self.http_get_latest_job)
+        self._app.route(route, method="GET", callback=self.http_get_latest_job)
 
     def get_latest_job(self, filter):
         try:
             client = OpenQA_Client(server=self._instance)
-            result = client.openqa_request('GET', 'jobs', filter)
-            jobs = sorted(result['jobs'], key=lambda x: str(x['t_finished']))
+            result = client.openqa_request("GET", "jobs", filter)
+            jobs = sorted(result["jobs"], key=lambda x: str(x["t_finished"]))
             if jobs:
-                return ([[job] for job in jobs if job['result']
-                        in ['passed', 'softfailed']][-1][0])
+                return [[job] for job in jobs if job["result"] in ["passed", "softfailed"]][-1][0]
             else:
                 raise LatestJobNotFound("no such job found")
         except Exception:
@@ -38,20 +34,19 @@ class LatestJob:
 
     def http_get_latest_job(self, arch, distri, flavor, version, test):
         filter = {}
-        filter['arch'] = arch
-        filter['distri'] = distri
-        filter['flavor'] = flavor
-        filter['version'] = version
-        filter['test'] = test
-        self.log.info("HTTP: get latest job for " + distri + " " + version
-                      + " " + arch + " " + flavor + " " + test)
+        filter["arch"] = arch
+        filter["distri"] = distri
+        filter["flavor"] = flavor
+        filter["version"] = version
+        filter["test"] = test
+        self.log.info("HTTP: get latest job for " + distri + " " + version + " " + arch + " " + flavor + " " + test)
         try:
             job = self.get_latest_job(filter)
-            bottle.response.content_type = 'text/text; charset=utf-8'
-            result = job['id']
+            bottle.response.content_type = "text/text; charset=utf-8"
+            result = job["id"]
             self.log.info("found job with ID " + result)
             return str(result)
         except LatestJobNotFound:
             self.log.info("No such job found")
-            bottle.response.body = 'not found'
-            bottle.response.status = '404 Not Found'
+            bottle.response.body = "not found"
+            bottle.response.status = "404 Not Found"

--- a/baremetal_support/lock.py
+++ b/baremetal_support/lock.py
@@ -1,13 +1,14 @@
 # Copyright (C) 2019-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-3.0
 
-from bottle import request, response
+from bottle import response
 import uuid
 from threading import Lock, Timer
 
 
 class HostAlreadyLocked(Exception):
     """Raised when a host should be locked but is already locked"""
+
     pass
 
 
@@ -27,28 +28,28 @@ class Host_Lock:
         self._app = app
         self.log = logger
 
-        self._app.route('/v1/host_lock/lock/<addr>',
-                        method="GET",
-                        callback=self.http_lock)
-        self._app.route('/v1/host_lock/lock/<addr>/<timeout:int>',
-                        method="GET",
-                        callback=self.http_lock)
-        self._app.route('/v1/host_lock/lock/<addr>/<token>',
-                        method="PUT",
-                        callback=self.http_unlock)
-        self._app.route('/v1/host_lock/lock_state/<addr>',
-                        method="GET",
-                        callback=self.http_lock_state)
+        self._app.route("/v1/host_lock/lock/<addr>", method="GET", callback=self.http_lock)
+        self._app.route(
+            "/v1/host_lock/lock/<addr>/<timeout:int>",
+            method="GET",
+            callback=self.http_lock,
+        )
+        self._app.route("/v1/host_lock/lock/<addr>/<token>", method="PUT", callback=self.http_unlock)
+        self._app.route(
+            "/v1/host_lock/lock_state/<addr>",
+            method="GET",
+            callback=self.http_lock_state,
+        )
 
     def my_timer(self, host):
         self.log.warn("Timer expired, unlocking " + host)
-        self.unlock_host(host, '', True)
+        self.unlock_host(host, "", True)
 
     def is_locked(self, host):
         self.mutex.acquire()
 
         try:
-            if self.locks[host] != '':
+            if self.locks[host] != "":
                 ret = True
                 self.log.info("Host " + host + " is locked")
             else:
@@ -64,21 +65,19 @@ class Host_Lock:
     def lock_host(self, host, timeout=0):
         self.mutex.acquire()
 
-        token = ''
+        token = ""
 
-        if host not in self.locks or self.locks[host] == '':
+        if host not in self.locks or self.locks[host] == "":
             token = uuid.uuid4().hex
             self.locks[host] = token
-            self.log.info("lock_host: Locking host " + host
-                          + " with token " + token)
+            self.log.info("lock_host: Locking host " + host + " with token " + token)
         else:
             self.mutex.release()
             self.log.info("lock_host: Host " + host + "is already locked")
             raise HostAlreadyLocked("Host is already locked")
 
         if timeout > 0:
-            self.log.info("lock_host: setting lock timeout for " + host
-                          + " to " + str(timeout))
+            self.log.info("lock_host: setting lock timeout for " + host + " to " + str(timeout))
             self.timeouts[host] = Timer(timeout, self.my_timer, [host])
             self.timeouts[host].start()
 
@@ -93,7 +92,7 @@ class Host_Lock:
         self.mutex.acquire()
 
         if force or self.locks[host] == token:
-            self.locks[host] = ''
+            self.locks[host] = ""
             self.log.info("unlock_host: unlocking " + host)
             if host in self.timeouts:
                 self.timeouts[host].cancel()
@@ -107,7 +106,7 @@ class Host_Lock:
         self.mutex.release()
 
     def http_lock(self, addr, timeout=0):
-        response.content_type = 'text/text; charset=utf-8'
+        response.content_type = "text/text; charset=utf-8"
         try:
             token = self.lock_host(addr, timeout)
             response.status = 200
@@ -117,7 +116,7 @@ class Host_Lock:
             response.status = 412
 
     def http_unlock(self, addr, token):
-        response.content_type = 'text/text; charset=utf-8'
+        response.content_type = "text/text; charset=utf-8"
         try:
             self.unlock_host(addr, token, False)
             response.body = "ok"
@@ -130,7 +129,7 @@ class Host_Lock:
         return response
 
     def http_lock_state(self, addr):
-        response.content_type = 'text/text; charset=utf-8'
+        response.content_type = "text/text; charset=utf-8"
         response.status = 200
         if self.is_locked(addr):
             response.body = "locked"

--- a/baremetal_support/logging.py
+++ b/baremetal_support/logging.py
@@ -10,8 +10,10 @@ class Logging:
         self.logger = logging.getLogger(name)
         self.set_level(level)
 
-        formatter = logging.Formatter(fmt="%(asctime)s %(name)s.%(levelname)s: %(message)s",
-                                      datefmt="%Y.%m.%d %H:%M:%S")
+        formatter = logging.Formatter(
+            fmt="%(asctime)s %(name)s.%(levelname)s: %(message)s",
+            datefmt="%Y.%m.%d %H:%M:%S",
+        )
 
         handler = logging.StreamHandler(stream=sys.stdout)
         handler.setFormatter(formatter)
@@ -31,7 +33,6 @@ class Logging:
             self.logger.setLevel(logging.CRITICAL)
         else:
             self.logger.setLevel(logging.NOTSET)
-
 
     def debug(self, msg):
         self.logger.debug(msg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "baremetal_support"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "bottle>=0.12.16",
+    "requests>=2.21.0",
+    "openqa_client",
+    "cfg_load",
+]
+
+[dependency-groups]
+dev = [
+    "ruff>=0.15",
+    "ty>=0.0.26",
+    "pytest>=4.3.1",
+    "pytest-cov>=2.6.1",
+    "codecov",
+]
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-bottle>=0.12.16
-pytest>=4.3.1
-pytest-cov>=2.6.1
-requests>=2.21.0
-pycodestyle>=2.5.0
-codecov
-openqa_client
-cfg_load

--- a/tests/test_baremetal_support.py
+++ b/tests/test_baremetal_support.py
@@ -4,10 +4,8 @@ import sys
 
 import pytest
 import requests
-import socket
 
 import signal
-import pytest_cov.embed
 
 from multiprocessing import Process
 from time import sleep
@@ -15,14 +13,14 @@ from time import sleep
 from baremetal_support.baremetal_support import Baremetal_Support
 from baremetal_support.logging import Logging
 
-hostname = 'localhost'
-port = '23456'
+hostname = "localhost"
+port = "23456"
 instance = "http://openqa.opensuse.org"
-url = 'http://' + hostname + ':' + port + '/v1/'
+url = "http://" + hostname + ":" + port + "/v1/"
 logger = Logging("baremetal support", "DEBUG")
 
+
 def cleanup(*_):
-    pytest_cov.embed.cleanup()
     sys.exit(1)
 
 
@@ -32,24 +30,26 @@ def server_task():
     assert isinstance(server, Baremetal_Support)
     server.start()
 
+
 def test_baremetal_support_methods():
     server = Baremetal_Support(hostname, port, logger, instance)
     assert not server._bootscript._is_ip("foobar")
 
+
 def test_baremetal_support():
-    use_ip = '10.0.0.1'
+    use_ip = "10.0.0.1"
 
-    url_bootscript = url + 'bootscript/script.ipxe/' + use_ip
-    url_localhost = url + 'bootscript/script.ipxe/' + '127.0.0.1'
-    url_get = url + 'bootscript/script.ipxe'
+    url_bootscript = url + "bootscript/script.ipxe/" + use_ip
+    url_localhost = url + "bootscript/script.ipxe/" + "127.0.0.1"
+    url_get = url + "bootscript/script.ipxe"
 
-    err_url = url + 'bootscript/script.ipxe/foobar'
-    err_url2 = url + 'bootscript/script.ipxe/31.32.33.34'
+    err_url = url + "bootscript/script.ipxe/foobar"
+    err_url2 = url + "bootscript/script.ipxe/31.32.33.34"
 
-    url_status = url + 'host_lock/lock_state/' + use_ip
-    url_lock = url + 'host_lock/lock/' + use_ip
-    url_lock_timeout = url + 'host_lock/lock/' + use_ip + '/10'
-    url_unlock = url + 'host_lock/lock/' + use_ip
+    url_status = url + "host_lock/lock_state/" + use_ip
+    url_lock = url + "host_lock/lock/" + use_ip
+    url_lock_timeout = url + "host_lock/lock/" + use_ip + "/10"
+    url_unlock = url + "host_lock/lock/" + use_ip
 
     text = "data foo bar"
 
@@ -57,11 +57,8 @@ def test_baremetal_support():
     p.start()
     sleep(1)
 
-
-
-
     # request bootscript api
-    r1 = requests.post(err_url, data='illegal')
+    r1 = requests.post(err_url, data="illegal")
     assert r1.status_code == 400
 
     r2 = requests.get(err_url)
@@ -69,7 +66,7 @@ def test_baremetal_support():
 
     r3 = requests.get(err_url2)
     assert r3.status_code == 404
-    assert r3.text == 'not found'
+    assert r3.text == "not found"
 
     r4 = requests.get(url_get)
     assert r4.status_code == 404
@@ -90,7 +87,7 @@ def test_baremetal_support():
     # test locking API
     r9 = requests.get(url_status)
     assert r9.status_code == 200
-    assert r9.text == 'unlocked'
+    assert r9.text == "unlocked"
 
     r10 = requests.get(url_lock)
     assert r10.status_code == 200
@@ -98,31 +95,31 @@ def test_baremetal_support():
 
     r11 = requests.get(url_status)
     assert r11.status_code == 200
-    assert r11.text == 'locked'
+    assert r11.text == "locked"
 
-    url_unlock2 = url_unlock + '/' + token
+    url_unlock2 = url_unlock + "/" + token
     r12 = requests.put(url_unlock2)
     assert r12.status_code == 200
-    assert r12.text == 'ok'
+    assert r12.text == "ok"
 
     r13 = requests.get(url_status)
     assert r13.status_code == 200
-    assert r13.text == 'unlocked'
+    assert r13.text == "unlocked"
 
     print(url_lock_timeout)
     r14 = requests.get(url_lock_timeout)
     assert r14.status_code == 200
-    assert r14.text != ''
+    assert r14.text != ""
 
     r15 = requests.get(url_status)
     assert r15.status_code == 200
-    assert r15.text == 'locked'
+    assert r15.text == "locked"
 
     sleep(15)
 
     r16 = requests.get(url_status)
     assert r16.status_code == 200
-    assert r16.text == 'unlocked'
+    assert r16.text == "unlocked"
 
     r17 = requests.get(url_lock)
     assert r17.status_code == 200
@@ -131,30 +128,29 @@ def test_baremetal_support():
     r18 = requests.get(url_lock)
     assert r18.status_code == 412
 
-    r19 = requests.put(url_unlock + '/0xdeadbeefcafebabe')
+    r19 = requests.put(url_unlock + "/0xdeadbeefcafebabe")
     assert r19.status_code == 403
 
-    url_unlock3 = url_unlock + '/' + token
+    url_unlock3 = url_unlock + "/" + token
     r20 = requests.put(url_unlock3)
     assert r20.status_code == 200
-    assert r20.text == 'ok'
+    assert r20.text == "ok"
 
     r21 = requests.get(url_status)
     assert r21.status_code == 200
-    assert r21.text == 'unlocked'
+    assert r21.text == "unlocked"
 
     r22 = requests.put(url_unlock3)
     assert r22.status_code == 412
 
     # this test verifies issue #19
-    url_bootscript1 = url + 'bootscript/script.ipxe/10.0.0.1'
-    url_bootscript2 = url + 'bootscript/script.ipxe/10.0.0.2'
+    url_bootscript1 = url + "bootscript/script.ipxe/10.0.0.1"
+    url_bootscript2 = url + "bootscript/script.ipxe/10.0.0.2"
     count = 0
     bootscript1 = "bootscript1"
     bootscript2 = "bootscript2"
-    while (count < 1000):
-        print("count: " + str(count));
-
+    while count < 1000:
+        print("count: " + str(count))
         r30 = requests.post(url_bootscript1, data=bootscript1)
         assert r30.status_code == 200
 
@@ -174,16 +170,15 @@ def test_baremetal_support():
         assert r34.text == bootscript2
 
         count = count + 1
- 
+
     p.terminate()
     p.join()
 
 
-
 def test_online_required():
 
-    url_jobid_good = url + 'latest_job/x86_64/opensuse/DVD/Tumbleweed/create_hdd_textmode'
-    url_jobid_bad = url + 'latest_job/MIPS/Gentoo/hardened/1.0/install_foobar'
+    url_jobid_good = url + "latest_job/x86_64/opensuse/DVD/Tumbleweed/create_hdd_textmode"
+    url_jobid_bad = url + "latest_job/MIPS/Gentoo/hardened/1.0/install_foobar"
 
     server = Baremetal_Support(hostname, port, logger, instance)
     signal.signal(signal.SIGTERM, cleanup)
@@ -194,7 +189,7 @@ def test_online_required():
 
     # tests for jobid.py
     try:
-        reachable = requests.get(instance)
+        _ = requests.get(instance)
         r = requests.get(url_jobid_good)
         assert r.status_code == 200
         assert r.text != ""
@@ -203,8 +198,6 @@ def test_online_required():
         assert r.status_code != 200
     except Exception:
         pytest.skip("instance unreachable")
-    finally: 
+    finally:
         p.terminate()
         p.join()
-
-

--- a/tests/test_bootscript.py
+++ b/tests/test_bootscript.py
@@ -25,7 +25,7 @@ def test_set():
     assert bs.get("10.0.0.1") == "bar"
 
     count = 0
-    while (count < 1000000):
+    while count < 1000000:
         bs.set("10.0.0.1", "bar")
         bs.set("10.0.0.2", "foobar")
         assert bs.get("10.0.0.1") == "bar"
@@ -41,7 +41,7 @@ def test_get():
     assert bs.get("10.0.0.1") == "foo"
 
     with raises(BootscriptNotFound):
-        bla = bs.get("20.21.22.23")
+        _ = bs.get("20.21.22.23")
 
 
 def test_extra():

--- a/tests/test_host_lock.py
+++ b/tests/test_host_lock.py
@@ -21,7 +21,7 @@ def test_my_timer():
     assert not locks.is_locked(host0)
     token = locks.lock_host(host0, 6)
     assert locks.is_locked(host0)
-    assert token != ''
+    assert token != ""
     time.sleep(2)
     assert locks.is_locked(host0)
     time.sleep(9)
@@ -95,4 +95,4 @@ def test_unlock_unlocked():
 
     assert not locks.is_locked(host0)
     with raises(HostNotLocked):
-        locks.unlock_host(host0, '')
+        locks.unlock_host(host0, "")

--- a/tests/test_jobid.py
+++ b/tests/test_jobid.py
@@ -13,9 +13,9 @@ logger = Logging("baremetal support", "DEBUG")
 
 
 def test_exception():
-    instance = 'http://openqa.opensuse.org'
+    instance = "http://openqa.opensuse.org"
     try:
-        reachable = requests.get(instance)
+        _ = requests.get(instance)
     except Exception:
         pytest.skip("instance unreachable")
 
@@ -23,30 +23,30 @@ def test_exception():
     lj = LatestJob(app, logger, instance)
 
     filter = {}
-    filter['arch'] = 'MIPS'
-    filter['distri'] = 'gentoo'
-    filter['flavor'] = 'hardened'
-    filter['version'] = '1.0'
-    filter['test'] = 'install_gentoo_mips'
+    filter["arch"] = "MIPS"
+    filter["distri"] = "gentoo"
+    filter["flavor"] = "hardened"
+    filter["version"] = "1.0"
+    filter["test"] = "install_gentoo_mips"
     with raises(LatestJobNotFound):
-        res = lj.get_latest_job(filter)
+        _ = lj.get_latest_job(filter)
 
 
 def test_get():
-    instance = 'http://openqa.opensuse.org'
+    instance = "http://openqa.opensuse.org"
     try:
-        reachable = requests.get(instance)
+        _ = requests.get(instance)
     except Exception:
         pytest.skip("instance unreachable")
 
     app = Bottle()
     lj = LatestJob(app, logger, instance)
     filter = {}
-    filter['arch'] = 'x86_64'
-    filter['distri'] = 'opensuse'
-    filter['flavor'] = 'DVD'
-    filter['version'] = 'Tumbleweed'
-    filter['test'] = 'create_hdd_textmode'
+    filter["arch"] = "x86_64"
+    filter["distri"] = "opensuse"
+    filter["flavor"] = "DVD"
+    filter["version"] = "Tumbleweed"
+    filter["test"] = "create_hdd_textmode"
 
     res = lj.get_latest_job(filter)
     assert res


### PR DESCRIPTION
- Replace black with ruff for linting and formatting
- Remove pycodestyle
- Add ty for type checking
- Migrate from pip+requirements.txt to uv+pyproject.toml
- Remove deprecated pytest_cov.embed module
- Add Makefile help target and improve .PHONY declarations
- Configure ruff with 120 char line-length
- Split runtime and dev dependencies properly

Reference: https://progress.opensuse.org/issues/191575